### PR TITLE
Utility to filter plotfiles

### DIFF
--- a/Docs/source/averagePlotfile.rst
+++ b/Docs/source/averagePlotfile.rst
@@ -2,7 +2,7 @@
 
 
 averagePlotfile - Create a pltfile by averaging existing pltfiles
-****************************************************************
+*****************************************************************
 
 Two tools exist for the purpose of averaging plotfiles. `averagePlotfile`
 assumes all plotfiles to be averaged have the same underlying BoxArrays, or
@@ -15,9 +15,8 @@ files have the same domain and base grid, and by default the same variables.
 list of variables, in which case that list must be present in all input files
 but otherwise the input files may contain different sets of variables.
 
-```
-Usage:
-    ./avgPlotfilesFlexible2d.gnu.MPI.ex infiles=$(ls -d plt*) [options]
-```
+Usage: ::
+
+  ./avgPlotfilesFlexible2d.gnu.MPI.ex infiles=$(ls -d plt*) [options]
 
 Example:

--- a/Docs/source/filterPlt.rst
+++ b/Docs/source/filterPlt.rst
@@ -5,25 +5,13 @@ filterPlt - apply a filter to a Plot file
 *****************************************
 
 This tool utilizes the PelePhysics PltFileManager utility to read in plot files
-and the PeleC Filter utility to apply different types of filters. To compile,
-it is necessary to define the AMREX_HOME, PELE_PHYSICS_HOME, and PELEC_HOME
+and the PelePhysics Filter utility to apply different types of filters. To compile,
+it is necessary to define the AMREX_HOME and PELE_PHYSICS_HOME
 variables in the GNUmakefile. For multilevel plot files, filtering can either
 be done with a constant absolute filter width, or a constant filter to grid
 ratio across levels. The filter to grid ratio on the base level must always be
-even. Consult PeleC to see different filter types offered. Right not the options
-are : ::
-
-  no_filter = 0,                 // 0
-  box,                           // 1
-  gaussian,                      // 2
-  box_3pt_approx,                // 3
-  box_5pt_approx,                // 4
-  box_3pt_optimized_approx,      // 5
-  box_5pt_optimized_approx,      // 6
-  gaussian_3pt_approx,           // 7
-  gaussian_5pt_approx,           // 8
-  gaussian_3pt_optimized_approx, // 9
-  gaussian_5pt_optimized_approx, // 10
+even. Consult `PelePhysics <https://amrex-combustion.github.io/PelePhysics/Utility.html#filter>`_
+to see different filter types offered.
 
 Usage: ::
 

--- a/Docs/source/filterPlt.rst
+++ b/Docs/source/filterPlt.rst
@@ -1,0 +1,36 @@
+.. highlight:: bash
+
+
+filterPlt - apply a filter to a Plot file
+*****************************************
+
+This tool utilizes the PelePhysics PltFileManager utility to read in plot files
+and the PeleC Filter utility to apply different types of filters. To compile,
+it is necessary to define the AMREX_HOME, PELE_PHYSICS_HOME, and PELEC_HOME
+variables in the GNUmakefile. For multilevel plot files, filtering can either
+be done with a constant absolute filter width, or a constant filter to grid
+ratio across levels. The filter to grid ratio on the base level must always be
+even. Consult PeleC to see different filter types offered. Right not the options
+are : ::
+
+  no_filter = 0,                 // 0
+  box,                           // 1
+  gaussian,                      // 2
+  box_3pt_approx,                // 3
+  box_5pt_approx,                // 4
+  box_3pt_optimized_approx,      // 5
+  box_5pt_optimized_approx,      // 6
+  gaussian_3pt_approx,           // 7
+  gaussian_5pt_approx,           // 8
+  gaussian_3pt_optimized_approx, // 9
+  gaussian_5pt_optimized_approx, // 10
+
+Usage: ::
+
+   ./filterPlt3d.gnu.MPI.ex infile=plt00000 [options]
+
+Help: ::
+
+   ./filterPlt3d.gnu.MPI.ex help=true
+
+Example:

--- a/Docs/source/index.rst
+++ b/Docs/source/index.rst
@@ -11,6 +11,7 @@ PeleAnalysis documentation
    buildPMF
    conditionalMean
    averagePlotfile
+   filterPlt
    combinePlts
    curvature
    grad

--- a/Src/GNUmakefile
+++ b/Src/GNUmakefile
@@ -1,5 +1,6 @@
-AMREX_HOME ?= ../../../amrex
-PELE_PHYSICS_HOME ?= ../../../PelePhysics
+AMREX_HOME ?= ../../amrex
+PELE_PHYSICS_HOME ?= ../../PelePhysics
+PELEC_HOME ?= ../../PeleC
 
 # AMReX
 DEBUG	      = FALSE
@@ -17,7 +18,8 @@ USE_CUDA      = FALSE
 #EBASE         = grad
 #EBASE         = combinePlts
 #EBASE         = isosurface
-EBASE         = flattenAMRFile
+#EBASE         = flattenAMRFile
+EBASE         = filterPlt
 #EBASE         = stream
 #EBASE         = partStream
 #EBASE         = blowOut
@@ -36,6 +38,7 @@ EBASE         = flattenAMRFile
 #EBASE         = jpdf
 #EBASE         = avgToPlane
 #EBASE          = avgPlotfiles
+#EBASE          = avgPlotfilesFlexible
 #EBASE          = amrToFE
 
 NEEDS_f90_SRC = FALSE
@@ -46,6 +49,13 @@ Ppack   += $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir)/Make.package)
 
 PPdirs  := Utility/PltFileManager
 Ppack   += $(foreach dir, $(PPdirs), $(PELE_PHYSICS_HOME)/$(dir)/Make.package)
+
+ifeq ($(EBASE),filterPlt)
+  VPATH_LOCATIONS += $(PELEC_HOME)/Source
+  INCLUDE_LOCATIONS += $(PELEC_HOME)/Source
+  CEXE_sources += Filter.cpp
+  CEXE_headers += Filter.H
+endif
 
 ifeq ($(EBASE),partStream)
   USE_PARTICLES = TRUE

--- a/Src/GNUmakefile
+++ b/Src/GNUmakefile
@@ -1,6 +1,5 @@
 AMREX_HOME ?= ../../amrex
 PELE_PHYSICS_HOME ?= ../../PelePhysics
-PELEC_HOME ?= ../../PeleC
 
 # AMReX
 DEBUG	      = FALSE
@@ -47,15 +46,8 @@ NEEDS_f90_SRC = FALSE
 Pdirs   := Base Boundary AmrCore Extern/amrdata LinearSolvers/MLMG
 Ppack   += $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir)/Make.package)
 
-PPdirs  := Utility/PltFileManager
+PPdirs  := Utility/PltFileManager Utility/Filter
 Ppack   += $(foreach dir, $(PPdirs), $(PELE_PHYSICS_HOME)/$(dir)/Make.package)
-
-ifeq ($(EBASE),filterPlt)
-  VPATH_LOCATIONS += $(PELEC_HOME)/Source
-  INCLUDE_LOCATIONS += $(PELEC_HOME)/Source
-  CEXE_sources += Filter.cpp
-  CEXE_headers += Filter.H
-endif
 
 ifeq ($(EBASE),partStream)
   USE_PARTICLES = TRUE

--- a/Src/avgPlotfilesFlexible.cpp
+++ b/Src/avgPlotfilesFlexible.cpp
@@ -18,6 +18,7 @@ print_usage (int,
   std::cerr << "\t     variables=<s1 s2 s3> where <s1> <s2> and <s3> are variable names to select for combined pltfile [DEF-> all possible]\n";
   std::cerr << "\t     output_max_level=<s> where <s> is the max refinement level to combine, zero-indexed [DEF->1000]\n";
   std::cerr << "\t     output_max_grid_size=<s> where <s> is the output max_grid_size. If all BoxArrays are the same, this is ignored. [DEF->32]\n";
+  std::cerr << "\t     interp_type=<int> where this determines the type of interpolation when FillPatching: 0 -> piecewise constant, 1 -> cell cons linear [DEF->1]\n";
 exit(1);
 }
 
@@ -63,6 +64,10 @@ main (int   argc,
      // Max grid size in output data
      int output_max_grid_size = 32;
      pp.query("output_max_grid_size", output_max_grid_size);
+
+     // Type of interpolation to do
+     int interp_type = 1;
+     pp.query("interp_type",interp_type);
 
 
      // ---------------------------------------------------------------------
@@ -169,12 +174,13 @@ main (int   argc,
      // Fillpatch tmp_data from each pltfile and add to running data
      Print() << "Fillpatching and combining..." << std::endl;
      for (int i = 0; i < plt_file_data.size(); ++i) {
+       Print() << "   working on file " << plotFileNames[i] << " (" << i+1 << "/" << plt_file_data.size() << ")" << std::endl;
        for (int lev = 0; lev < nlevels; ++lev) {
          if (all_vars) {
-           plt_file_data[i]->fillPatchFromPlt(lev, level_geometries[lev], 0, 0, nvar, tmp_data[lev]);
+           plt_file_data[i]->fillPatchFromPlt(lev, level_geometries[lev], 0, 0, nvar, tmp_data[lev], interp_type);
          } else {
            for (int var = 0; var < nvar; ++var) {
-             plt_file_data[i]->fillPatchFromPlt(lev, level_geometries[lev], var_idxs[i][var], var, 1, tmp_data[lev]);
+             plt_file_data[i]->fillPatchFromPlt(lev, level_geometries[lev], var_idxs[i][var], var, 1, tmp_data[lev], interp_type);
            }
          }
          MultiFab::Add(running_data[lev], tmp_data[lev], 0, 0, nvar, 0);

--- a/Src/filterPlt.cpp
+++ b/Src/filterPlt.cpp
@@ -1,0 +1,172 @@
+/** \file unit-tests-main.cpp
+ *  Entry point for unit tests
+ */
+
+#include <string>
+#include <iostream>
+
+#include <AMReX_ParmParse.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_DataServices.H>
+#include <AMReX_MultiFabUtil.H>
+#include <AMReX_PlotFileUtil.H>
+#include <AMReX_BLFort.H>
+#include <Filter.H>
+
+std::string
+getFileRoot(const std::string& infile)
+{
+  std::vector<std::string> tokens = amrex::Tokenize(infile,std::string("/"));
+  return tokens[tokens.size()-1];
+}
+
+
+void write_plotfile (const std::string &plotfilename,
+                              int nlevels,
+                              const amrex::Vector<const amrex::MultiFab*> &mf,
+                              const amrex::Vector<std::string> &varnames,
+                              const amrex::Vector<amrex::Geometry> &geom,
+                              amrex::Real time,
+                              const amrex::Vector<int> &level_steps)
+{
+
+  amrex::Vector<amrex::IntVect> ref_ratio(nlevels-1,{AMREX_D_DECL(2, 2, 2)});
+  amrex::WriteMultiLevelPlotfile(plotfilename, nlevels, mf, varnames,
+                            geom, time, level_steps,ref_ratio);
+}
+
+int
+main(int argc, char** argv)
+{
+
+    amrex::Initialize(argc,argv);
+    // ---------------------------------------------------------------------
+    // ParmParse
+    // ---------------------------------------------------------------------
+    amrex::ParmParse pp;
+
+    std::string infile        = "";
+    int finestLevel           = 1000;
+    amrex::Vector<Filter> les_filter;
+    int les_filter_type = 1;
+    int les_filter_fgr  = 2;
+    bool same_fgr_all_levels = false;
+    int coord = 0;
+
+    pp.get("infile",infile);
+    pp.query("finestLevel",finestLevel);
+    pp.query("filter_type",les_filter_type);
+    pp.query("base_fgr",les_filter_fgr); // filter to grid ratio
+    pp.query("same_fgr_all_levels", same_fgr_all_levels);
+    int max_grid_size = 32;
+    pp.query("max_grid_size",max_grid_size);
+
+    // Initialize DataService
+    amrex::DataServices::SetBatchMode();
+    amrex::Amrvis::FileType fileType(amrex::Amrvis::NEWPLT);
+    amrex::DataServices dataServices(infile, fileType);
+    if( ! dataServices.AmrDataOk()) {
+      amrex::DataServices::Dispatch(amrex::DataServices::ExitRequest, NULL);
+    }
+    amrex::AmrData& amrData = dataServices.AmrDataRef();
+
+    // Plotfile global infos
+    finestLevel = std::min(finestLevel,amrData.FinestLevel());
+    int Nlev = finestLevel + 1;
+
+    const amrex::Vector<std::string>& plotVarNames = amrData.PlotVarNames();
+    amrex::RealBox rb(&(amrData.ProbLo()[0]),
+               &(amrData.ProbHi()[0]));
+    amrex::Vector<int> is_per(AMREX_SPACEDIM,0);
+
+    int ncomp = amrData.NComp();
+    amrex::Print() << "Number of scalars in the original file: " << ncomp << std::endl;
+
+
+    std::string VxName  = "x_velocity";
+    std::string VyName  = "y_velocity";
+    std::string VzName  = "z_velocity";
+    std::string rhoName = "density";
+    amrex::Vector<std::string> compNames;
+    int ncomp_filter = 4;
+    compNames.resize(ncomp_filter);
+
+    compNames[0] = "x_velocity";
+    compNames[1] = "y_velocity";
+    compNames[2] = "z_velocity";
+    compNames[3] = "density";
+
+    int idVx  = -1;
+    int idVy  = -1;
+    int idVz  = -1;
+    int idRho = -1;
+
+    for (int i=0; i<amrData.PlotVarNames().size(); ++i)
+    {
+      if (amrData.PlotVarNames()[i] == VxName)  idVx = i;
+      if (amrData.PlotVarNames()[i] == VyName)  idVy = i;
+      if (amrData.PlotVarNames()[i] == VzName)  idVz = i;
+      if (amrData.PlotVarNames()[i] == rhoName) idRho = i;
+    }
+
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> indata(Nlev);
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> outdata(Nlev);
+
+    amrex::Vector<amrex::Geometry> geoms(Nlev);
+
+    amrex::Vector<int> destFillComps(ncomp_filter);
+    for (int i=0; i<ncomp_filter; ++i) destFillComps[i] = i;
+
+    int les_filter_fgr_lev = les_filter_fgr;
+    for (int lev=0; lev<Nlev; ++lev)
+    {
+      // Initialize filter stuff
+      if ((!same_fgr_all_levels) && (lev > 0)) {
+        les_filter_fgr_lev *= amrData.RefRatio()[lev - 1];
+      }
+
+      les_filter[lev] = Filter(les_filter_type, les_filter_fgr_lev);
+      int nGrowF = les_filter[lev].get_filter_ngrow();
+      int nGrow  = 0;
+
+      const auto& domain = amrData.ProbDomain()[lev];
+      amrex::BoxArray ba(domain);
+      ba.maxSize(max_grid_size);
+      const amrex::DistributionMapping dm(ba);
+
+      geoms[lev].define(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
+
+      indata [lev].reset(new amrex::MultiFab(ba,dm,ncomp_filter,nGrowF));
+      outdata[lev].reset(new amrex::MultiFab(ba,dm,ncomp_filter,nGrow));
+
+      amrex::Print() << "Reading data..." << std::endl;
+      amrData.FillVar(*indata[lev],lev,compNames,destFillComps);
+      amrex::Print() << "Done!" << std::endl;
+    }
+
+    amrex::Print() << "Filtering data..." << std::endl;
+    for (int lev=0; lev<Nlev; ++lev)
+    {
+      amrex::Print() << "on level "<< lev << std::endl;
+
+      for (amrex::MFIter mfi(*indata[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+
+        amrex::FArrayBox& fab_in  = (*indata[lev])[mfi];
+        amrex::FArrayBox& fab_out = (*outdata[lev])[mfi];
+        const amrex::Box& box = mfi.validbox();
+
+        les_filter[lev].apply_filter(box, fab_in, fab_out);
+      }
+    }
+    amrex::Print() << "Done!" << std::endl;
+
+    amrex::Print() << "Saving filtered data..." << std::endl;
+    std::string outfile(getFileRoot(infile) + "_filtered");
+    //bool verb = false;
+
+    //    int levelSteps = 0;
+
+    write_plotfile(outfile,Nlev,amrex::GetVecOfConstPtrs(outdata),compNames,geoms,amrData.Time(),amrex::Vector<int>(Nlev, 0));
+    amrex::Print() << "Done!" << std::endl;
+
+}


### PR DESCRIPTION
Based on code originally written by @bssoriano.

Use the filter functionality that was originally in PeleC for LES to filter plot files. User can specify a box or Gaussian filter. Filter width must be a factor of 2 multiple of the grid. The user can specify how many levels should be filtered and whether the absolute filter width or filter to grid ratio should be kept constant across levels. Not EB aware. Non-periodic domain boundary cells overlapped by the filter stencil are filled using first order extrapolation.