### PR TITLE
Add basic CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,142 @@
+name: PeleAnalysis-CI
+
+on:
+   workflow_dispatch:
+   push:
+     branches: [development]
+   pull_request:
+     branches: [development]
+
+concurrency:
+  group: ${{github.ref}}-${{github.head_ref}}-ci
+  cancel-in-progress: true
+
+jobs:
+
+# This is mostly just copied from the PelePhysics CI
+# and pruned somewhat. Stuff to add back indicated
+# with TODOs
+#
+## TODO:
+#
+#  Formatting:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Clone
+#        uses: actions/checkout@v4
+#      - name: Check formatting
+#        uses: DoozyX/clang-format-lint-action@v0.18.2
+#        with:
+#          source: './Source ./Testing ./Mechanisms'
+#          exclude: '.'
+#          extensions: 'H,h,cpp'
+#          clangFormatVersion: 18
+#
+#  Codespell:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Clone
+#        uses: actions/checkout@v4
+#        with:
+#          submodules: false
+#      - name: Python
+#        uses: actions/setup-python@v5
+#        with:
+#          python-version: '3.11'
+#      - name: Dependencies
+#        run: |
+#          # Install Python packages
+#          python -m pip install --upgrade pip
+#          pip install codespell
+#      - name: Run codespell
+#        run: codespell
+
+  TestAnalysisCodes:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        comp: [gnu, llvm] # TODO: cuda, hip, sycl
+        python-version: ['3.11']
+        poetry-version: ['1.4.2']
+        include:
+          - comp: gnu
+            amrex_build_args: 'COMP=gnu'
+            dependency_cmds:
+          - comp: gnu-debug
+            amrex_build_args: 'COMP=gnu DEBUG=TRUE'
+            dependency_cmds:
+          - comp: llvm
+            amrex_build_args: 'COMP=llvm'
+            dependency_cmds:
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{matrix.python-version}}
+      - name: Clone PeleAnalysis
+        uses: actions/checkout@v4
+        with:
+          path: PeleAnalysis-${{matrix.comp}}
+          submodules: recursive
+      - name: Set Environment Variables
+        run: |
+          echo "PELE_ANALYSIS_HOME=${{github.workspace}}/PeleAnalysis-${{matrix.comp}}" >> $GITHUB_ENV
+          echo "BASE_WORKING_DIRECTORY=${{github.workspace}}/PeleAnalysis-${{matrix.comp}}/Src" >> $GITHUB_ENV
+          echo "MODELSPECIFIC_WORKING_DIRECTORY=${{github.workspace}}/PeleAnalysis-${{matrix.comp}}/Src/ModelSpecificAnalysis" >> $GITHUB_ENV
+          echo "NPROCS=$(nproc)" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESS=1" >> $GITHUB_ENV
+          echo "CCACHE_COMPRESSLEVEL=5" >> $GITHUB_ENV
+          echo "CCACHE_LOGFILE=${{github.workspace}}/ccache.log.txt" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=1G" >> $GITHUB_ENV
+      - name: Install Ccache
+        run: |
+          wget https://github.com/ccache/ccache/releases/download/v4.8/ccache-4.8-linux-x86_64.tar.xz
+          tar xvf ccache-4.8-linux-x86_64.tar.xz
+          sudo cp -f ccache-4.8-linux-x86_64/ccache /usr/local/bin/
+      - name: Set Up Ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{github.workflow}}-${{github.job}}-${{matrix.comp}}-git-${{github.sha}}
+          restore-keys: |
+               ccache-${{github.workflow}}-${{github.job}}-${{matrix.comp}}-git-
+      - name: Dependency (qslim)
+        working-directory: ${{env.BASE_WORKING_DIRECTORY}}
+        run: |
+          cmake --version
+          # make qslim EBASE=decimateMEF ${{matrix.amrex_build_args}};
+      - name: Dependency (sundials)
+        working-directory: ${{env.MODELSPECIFIC_WORKING_DIRECTORY}}
+        run: |
+          cmake --version
+          make TPL ${{matrix.amrex_build_args}};
+      - name: Test (Src)
+        working-directory: ${{env.BASE_WORKING_DIRECTORY}}
+        run: |
+          ccache -z
+          #for TYPE in template avgPlotfiles isosurface decimateMEF partStream; do \
+          for TYPE in template avgPlotfiles isosurface partStream; do \
+            printf "\n-------- ${TYPE} --------\n";
+            make -j ${{env.NPROCS}} EBASE=${TYPE} USE_CCACHE=TRUE ${{matrix.amrex_build_args}}; \
+            make realclean; \
+            if [ $? -ne 0 ]; then exit 1; fi; \
+          done
+      - name: Src ccache report
+        working-directory: ${{env.BASE_WORKING_DIRECTORY}}
+        run: |
+          ccache -s
+          du -hs ${HOME}/.cache/ccache
+      - name: Test (ModelSpecificAnalysis)
+        working-directory: ${{env.MODELSPECIFIC_WORKING_DIRECTORY}}
+        run: |
+          ccache -z
+          for TYPE in plotTransportCoeff plotTYtoLe; do \
+            make -j ${{env.NPROCS}} EBASE=${TYPE} USE_CCACHE=TRUE ${{matrix.amrex_build_args}}; \
+            make realclean; \
+            if [ $? -ne 0 ]; then exit 1; fi; \
+          done
+      - name: ModelSpecificAnalysis ccache report
+        working-directory: ${{env.MODELSPECIFIC_WORKING_DIRECTORY}}
+        run: |
+          ccache -s
+          du -hs ${HOME}/.cache/ccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         working-directory: ${{env.BASE_WORKING_DIRECTORY}}
         run: |
           cmake --version
-          # make qslim EBASE=decimateMEF ${{matrix.amrex_build_args}};
+          make qslim EBASE=decimateMEF ${{matrix.amrex_build_args}};
       - name: Dependency (sundials)
         working-directory: ${{env.MODELSPECIFIC_WORKING_DIRECTORY}}
         run: |
@@ -114,8 +114,7 @@ jobs:
         working-directory: ${{env.BASE_WORKING_DIRECTORY}}
         run: |
           ccache -z
-          #for TYPE in template avgPlotfiles isosurface decimateMEF partStream; do \
-          for TYPE in template avgPlotfiles isosurface partStream; do \
+          for TYPE in template avgPlotfiles isosurface decimateMEF partStream; do \
             printf "\n-------- ${TYPE} --------\n";
             make -j ${{env.NPROCS}} EBASE=${TYPE} USE_CCACHE=TRUE ${{matrix.amrex_build_args}}; \
             make realclean; \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
         working-directory: ${{env.BASE_WORKING_DIRECTORY}}
         run: |
           cmake --version
+          sudo apt-get update && sudo apt-get install libgl1-mesa-dev libglu1-mesa-dev
           make qslim EBASE=decimateMEF ${{matrix.amrex_build_args}};
       - name: Dependency (sundials)
         working-directory: ${{env.MODELSPECIFIC_WORKING_DIRECTORY}}

--- a/Src/GNUmakefile
+++ b/Src/GNUmakefile
@@ -46,7 +46,7 @@ EBASE		= template
 CEXE_sources += $(EBASE).cpp
 
 ifeq ($(EBASE),partStream)
-  NEED_PARTICLES = TRUE
+  USE_PARTICLES = TRUE
   CEXE_headers += StreamData.H    StreamPC.H
   CEXE_sources += StreamData.cpp  StreamPC.cpp
 endif

--- a/Src/ModelSpecificAnalysis/GNUmakefile
+++ b/Src/ModelSpecificAnalysis/GNUmakefile
@@ -9,7 +9,7 @@ DEBUG      = FALSE
 
 # Compiler
 COMP	   = gnu
-USE_MPI    = TRUE
+USE_MPI    = FALSE
 USE_OMP    = FALSE
 USE_CUDA   = FALSE
 USE_HIP    = FALSE

--- a/Src/StreamData.cpp
+++ b/Src/StreamData.cpp
@@ -693,7 +693,7 @@ static void DoIt(const Vector<int>& comps,
       for (int n=0; n<comps.size(); ++n) {
         const FArrayBox& stream_fab = *(Cstream.getFab(node->amr_lev,node->box_idx,comps[n]));
         for (int j=stream.StreamIdxLo(); j<=stream.StreamIdxHi(); ++j) {
-          IntVect iv(D_DECL(local_node_id,j,0));
+          IntVect iv(AMREX_D_DECL(local_node_id,j,0));
           senddata[offsets[to_proc]++] = stream_fab(iv,0);
         }
       }
@@ -714,8 +714,8 @@ static void DoIt(const Vector<int>& comps,
 
   if (num_recv_nodes>0) {
       
-    Box d_box(IntVect(D_DECL(0,stream.StreamIdxLo(),0)),
-              IntVect(D_DECL(num_recv_nodes-1,stream.StreamIdxHi(),0)));
+    Box d_box(IntVect(AMREX_D_DECL(0,stream.StreamIdxLo(),0)),
+              IntVect(AMREX_D_DECL(num_recv_nodes-1,stream.StreamIdxHi(),0)));
       
     for (int n=0; n<comps.size(); ++n) {
         dest[comps[n]]->resize(d_box,1);
@@ -738,7 +738,7 @@ static void DoIt(const Vector<int>& comps,
         int local_node_id = global_to_local_node_ids[it1->first];
         for (int n=0; n<comps.size(); ++n) {
           for (int j=d_box.smallEnd()[1]; j<=d_box.bigEnd()[1]; ++j) {
-            IntVect idx(D_DECL(local_node_id,j,0));
+            IntVect idx(AMREX_D_DECL(local_node_id,j,0));
             (*dest[comps[n]])(idx,0) = *dest_loc++;
           }
         }

--- a/Src/avgToPlane.cpp
+++ b/Src/avgToPlane.cpp
@@ -98,8 +98,8 @@ main (int   argc,
       pp.getarr("box",inBox,0,nx);
       int d=BL_SPACEDIM;
       BL_ASSERT(inBox.size()==2*d);
-      subbox=Box(IntVect(D_DECL(inBox[0],inBox[1],inBox[2])),
-                 IntVect(D_DECL(inBox[d],inBox[d+1],inBox[d+2])),
+      subbox=Box(IntVect(AMREX_D_DECL(inBox[0],inBox[1],inBox[2])),
+                 IntVect(AMREX_D_DECL(inBox[d],inBox[d+1],inBox[d+2])),
                  IndexType::TheCellType());
     }
 
@@ -248,7 +248,7 @@ void pixelizeData(const FArrayBox& data, int slicedir, int sliceloc,
 
   Print() << Box(se,be) << std::endl;
 
-  IntVect img(D_DECL(box.length(d[0]) - 1,box.length(d[1]) - 1,0));
+  IntVect img(AMREX_D_DECL(box.length(d[0]) - 1,box.length(d[1]) - 1,0));
   image.resize(Box(IntVect::TheZeroVector(),img),1);
 
   IntVect div;
@@ -259,7 +259,7 @@ void pixelizeData(const FArrayBox& data, int slicedir, int sliceloc,
     for (int j=se[d[1]]; j<=be[d[1]]; ++j) {
       div[d[0]] = i;
       div[d[1]] = j;
-      image(IntVect(D_DECL(i - se[d[0]],j - se[d[1]],0)),0) =
+      image(IntVect(AMREX_D_DECL(i - se[d[0]],j - se[d[1]],0)),0) =
         std::max(0,(int)(nvm1*std::min( (data(div,0) - data_min)/del,1.0))); 
     }
   }

--- a/Src/binMEF.cpp
+++ b/Src/binMEF.cpp
@@ -611,11 +611,11 @@ main (int   argc,
         Box box;
         if (nc==1)
         {
-          box = Box(IntVect::TheZeroVector(),IntVect(D_DECL(nBins[0]-1,0,0)));
+          box = Box(IntVect::TheZeroVector(),IntVect(AMREX_D_DECL(nBins[0]-1,0,0)));
         }
         else
         {
-          box = Box(IntVect::TheZeroVector(),IntVect(D_DECL(nBins[0]-1,nBins[1]-1,0)));
+          box = Box(IntVect::TheZeroVector(),IntVect(AMREX_D_DECL(nBins[0]-1,nBins[1]-1,0)));
         }
             
         FArrayBox outFab(box,1);

--- a/Src/buildDistance.cpp
+++ b/Src/buildDistance.cpp
@@ -103,16 +103,16 @@ main (int   argc,
 
     int nCell = 64; pp.query("nCell",nCell);
     int max_grid_size = 32; pp.query("max_grid_size",max_grid_size);
-    Box domain(IntVect(D_DECL(0,0,0)),
-               //IntVect(D_DECL(nCell-1,nCell-1,nCell-1)));
-               IntVect(D_DECL(64-1,64-1,192-1)));
+    Box domain(IntVect(AMREX_D_DECL(0,0,0)),
+               //IntVect(AMREX_D_DECL(nCell-1,nCell-1,nCell-1)));
+               IntVect(AMREX_D_DECL(64-1,64-1,192-1)));
     BoxArray grids(domain);
     grids.maxSize(max_grid_size);
-    //RealBox probDomain({D_DECL(0,0,0)},{D_DECL(1,1,1)});
-    //RealBox probDomain({D_DECL(-0.0033,-0.0033,-0.0099)},{D_DECL(0.0033,0.0033,.0099)});
-    RealBox probDomain({D_DECL(0,0,0)},{D_DECL(0.03,0.03,.09)});
+    //RealBox probDomain({AMREX_D_DECL(0,0,0)},{AMREX_D_DECL(1,1,1)});
+    //RealBox probDomain({AMREX_D_DECL(-0.0033,-0.0033,-0.0099)},{AMREX_D_DECL(0.0033,0.0033,.0099)});
+    RealBox probDomain({AMREX_D_DECL(0,0,0)},{AMREX_D_DECL(0.03,0.03,.09)});
     
-    Array<int,AMREX_SPACEDIM> is_periodic = {D_DECL(0,0,0)};
+    Array<int,AMREX_SPACEDIM> is_periodic = {AMREX_D_DECL(0,0,0)};
     Geometry geom(domain,probDomain,0,is_periodic);
     const Real* dx = geom.CellSize();
     const Real* plo = geom.ProbLo();
@@ -129,12 +129,12 @@ main (int   argc,
       std::vector<Vec3ui> faceList;
 
       for (int node=0; node<nNodes; ++node) {
-        const IntVect iv(D_DECL(node,0,0));
-        vertList.push_back(Vec3f(D_DECL(nodes(iv,0),nodes(iv,1),nodes(iv,2))));
+        const IntVect iv(AMREX_D_DECL(node,0,0));
+        vertList.push_back(Vec3f(AMREX_D_DECL(nodes(iv,0),nodes(iv,1),nodes(iv,2))));
       }
       for (int elt=0; elt<nElts; ++elt) {
         int offset = elt * nodesPerElt;
-        faceList.push_back(Vec3ui(D_DECL(faceData[offset]-1,faceData[offset+1]-1,faceData[offset+2]-1)));
+        faceList.push_back(Vec3ui(AMREX_D_DECL(faceData[offset]-1,faceData[offset+1]-1,faceData[offset+2]-1)));
       }
 
       const Box& vbox = distance[mfi].box();

--- a/Src/partStream.cpp
+++ b/Src/partStream.cpp
@@ -36,7 +36,7 @@ GetSeedLocations (const StreamParticleContainer& spc)
       for (MFIter mfi = spc.MakeMFIter(lev); mfi.isValid(); ++mfi)
       {
         const Box& tile_box  = mfi.tilebox();
-        if (BL_SPACEDIM<3 || tile_box.contains(IntVect(D_DECL(0,50,107)))) {
+        if (BL_SPACEDIM<3 || tile_box.contains(IntVect(AMREX_D_DECL(0,50,107)))) {
 
           mask.resize(tile_box,1);
           mask.setVal(1);
@@ -127,7 +127,7 @@ main (int   argc,
     ParmParse pp;
 
     std::string infile; pp.get("infile",infile);
-    Vector<std::string> inVarNames = {D_DECL("x_velocity", "y_velocity", "z_velocity")};
+    Vector<std::string> inVarNames = {AMREX_D_DECL("x_velocity", "y_velocity", "z_velocity")};
 
     PlotFileData pf(infile);
     int finestLevel = pf.finestLevel();
@@ -136,7 +136,7 @@ main (int   argc,
     Vector<DistributionMapping> dms(finestLevel+1);
     Vector<int> ratios(finestLevel);
 
-    Array<int,AMREX_SPACEDIM> is_per = {D_DECL(0, 0, 0)};
+    Array<int,AMREX_SPACEDIM> is_per = {AMREX_D_DECL(0, 0, 0)};
     RealBox rb(pf.probLo(),pf.probHi());
 
     int Nlev = finestLevel + 1;

--- a/Src/regridPlt.cpp
+++ b/Src/regridPlt.cpp
@@ -139,7 +139,7 @@ main (int   argc,
       levelSteps[lev] = 666;
       if (lev < Nlev-1) {
         int r = amrData.RefRatio()[lev];
-        refRatio[lev] = IntVect(D_DECL(r,r,r));
+        refRatio[lev] = IntVect(AMREX_D_DECL(r,r,r));
       }
       dat[lev] = fileData[lev];
     }

--- a/Src/sampleStreamlines.cpp
+++ b/Src/sampleStreamlines.cpp
@@ -521,7 +521,7 @@ find_containing_box(const FArrayBox&   XYZ,
     {
         for (int j=1; j<XYZ.box().length(0); ++j)
         {
-            strIV = IntVect(D_DECL(j,0,0));
+            strIV = IntVect(AMREX_D_DECL(j,0,0));
             Real loc = XYZ(strIV,idXYZ[d]);
             locL[d] = std::min(locL[d], loc);
             locH[d] = std::max(locH[d], loc);

--- a/Src/slicePlot.cpp
+++ b/Src/slicePlot.cpp
@@ -110,7 +110,7 @@ void pixelizeData(const FArrayBox& data, int slicedir, int sliceloc,
 
   Print() << Box(se,be) << std::endl;
 
-  IntVect img(D_DECL(box.length(d[0]) - 1,box.length(d[1]) - 1,0));
+  IntVect img(AMREX_D_DECL(box.length(d[0]) - 1,box.length(d[1]) - 1,0));
   image.resize(Box(IntVect::TheZeroVector(),img),1);
 
   IntVect div;
@@ -121,7 +121,7 @@ void pixelizeData(const FArrayBox& data, int slicedir, int sliceloc,
     for (int j=se[d[1]]; j<=be[d[1]]; ++j) {
       div[d[0]] = i;
       div[d[1]] = j;
-      image(IntVect(D_DECL(i - se[d[0]],j - se[d[1]],0)),0) =
+      image(IntVect(AMREX_D_DECL(i - se[d[0]],j - se[d[1]],0)),0) =
         std::max(0,(int)(nvm1*std::min( (data(div,0) - data_min)/del,1.0))); 
     }
   }

--- a/Src/stream.cpp
+++ b/Src/stream.cpp
@@ -504,7 +504,7 @@ main (int   argc,
       nodesPerElt = 1;
       nElts = 1;
       faceData.resize(nElts*nodesPerElt,1);
-      surfNames = {D_DECL("X", "Y", "Z")};
+      surfNames = {AMREX_D_DECL("X", "Y", "Z")};
       Vector<Real> loc(BL_SPACEDIM); 
       pp.getarr("seedLoc",loc,0,BL_SPACEDIM);
       for (int i=0; i<BL_SPACEDIM; ++i) nodes(IntVect::TheZeroVector(),i) = loc[i];
@@ -528,7 +528,7 @@ main (int   argc,
         }
         //faceData[i] = i;
       }
-      surfNames = {D_DECL("X", "Y", "Z")};
+      surfNames = {AMREX_D_DECL("X", "Y", "Z")};
     }
     io_time += ParallelDescriptor::second() - strt_io;
     if (ParallelDescriptor::IOProcessor() && verbose>0)
@@ -736,7 +736,7 @@ main (int   argc,
         if (lev < finestLevel)
             baf_c = BoxArray(amrData.boxArray(lev+1)).coarsen(amrData.RefRatio()[lev]);
 
-        BoxList bl(IndexType(D_DECL(IndexType::CELL,
+        BoxList bl(IndexType(AMREX_D_DECL(IndexType::CELL,
                                     IndexType::CELL,
                                     IndexType::CELL)));
 
@@ -759,7 +759,7 @@ main (int   argc,
             }
             else
             {
-                bl.push_back(Box(IntVect(D_DECL(0,-nRKh,0)),IntVect(D_DECL(num_inside-1,-nRKh+nRKsteps-1,0))));
+                bl.push_back(Box(IntVect(AMREX_D_DECL(0,-nRKh,0)),IntVect(AMREX_D_DECL(num_inside-1,-nRKh+nRKsteps-1,0))));
             }
         }
 
@@ -1257,8 +1257,8 @@ add_angle_to_surf(const Vector<MultiFab*>&  paths,
 
                     for (int d=0; d<BL_SPACEDIM; ++d)
                     {
-                        dx[d] = pth(IntVect(D_DECL(i,loPath,0)),xComp+d)
-                            -   pth(IntVect(D_DECL(i,hiPath,0)),xComp+d);
+                        dx[d] = pth(IntVect(AMREX_D_DECL(i,loPath,0)),xComp+d)
+                            -   pth(IntVect(AMREX_D_DECL(i,hiPath,0)),xComp+d);
                         mag += dx[d]*dx[d];
                     }
                     mag = std::sqrt(mag);
@@ -1411,27 +1411,27 @@ add_cold_strain_to_surf(const Vector<MultiFab*>&  paths,
                 // For each path, search for where TComp equals TVal
                 for (int i=0; i<Npaths; ++i)
                 {
-                    IntVect sIdx(D_DECL(i,0,0));
+                    IntVect sIdx(AMREX_D_DECL(i,0,0));
                     bool foundIt = false;
                     int lIdx=loPath, rIdx=lIdx+1;
-                    Real lVal = pth(IntVect(D_DECL(i,lIdx,0)),TComp), rVal=lVal;
+                    Real lVal = pth(IntVect(AMREX_D_DECL(i,lIdx,0)),TComp), rVal=lVal;
                     Real frac = 0.0;
                     
-                    if (pth(IntVect(D_DECL(i,loPath,0)),TComp) > pth(IntVect(D_DECL(i,loPath,0)),TComp))
+                    if (pth(IntVect(AMREX_D_DECL(i,loPath,0)),TComp) > pth(IntVect(AMREX_D_DECL(i,loPath,0)),TComp))
                         amrex::Abort("Path oriented backwards");
                     
-                    if (TVal > pth(IntVect(D_DECL(i,hiPath,0)),TComp))
+                    if (TVal > pth(IntVect(AMREX_D_DECL(i,hiPath,0)),TComp))
                     {
                         lIdx=hiPath-1;
                         rIdx=hiPath;
-                        lVal = pth(IntVect(D_DECL(i,lIdx,0)),TComp); rVal=lVal;
+                        lVal = pth(IntVect(AMREX_D_DECL(i,lIdx,0)),TComp); rVal=lVal;
                         frac = 1.0;
                     }
                     else if (TVal > lVal)
                     {
                         for (int j=loPath; (j<hiPath) && (!foundIt); ++j)
                         {
-                            rIdx = lIdx + 1;  rVal = pth(IntVect(D_DECL(i,rIdx,0)),TComp);
+                            rIdx = lIdx + 1;  rVal = pth(IntVect(AMREX_D_DECL(i,rIdx,0)),TComp);
                             
                             if ( (TVal >= lVal) && (TVal < rVal) )
                             {
@@ -1446,8 +1446,8 @@ add_cold_strain_to_surf(const Vector<MultiFab*>&  paths,
                     }
 
                     // Interpolate strainComp to this location
-                    const Real& xL = pth(IntVect(D_DECL(i,lIdx,0)),strainComp);
-                    const Real& xR = pth(IntVect(D_DECL(i,rIdx,0)),strainComp);
+                    const Real& xL = pth(IntVect(AMREX_D_DECL(i,lIdx,0)),strainComp);
+                    const Real& xR = pth(IntVect(AMREX_D_DECL(i,rIdx,0)),strainComp);
                     my_altSurfData.push_back(xL + (xR-xL) * frac);
                 }
             }
@@ -1598,27 +1598,27 @@ add_thermal_thickness_to_surf(const Vector<MultiFab*>&  paths,
                 {
                     Real loLoc, hiLoc;
                     {
-                        IntVect sIdx(D_DECL(i,0,0));
+                        IntVect sIdx(AMREX_D_DECL(i,0,0));
                         bool foundIt = false;
                         int lIdx=loPath, rIdx=lIdx+1;
-                        Real lVal = pth(IntVect(D_DECL(i,lIdx,0)),thickComp), rVal=lVal;
+                        Real lVal = pth(IntVect(AMREX_D_DECL(i,lIdx,0)),thickComp), rVal=lVal;
                         Real frac = 0.0;
                         
-                        if (pth(IntVect(D_DECL(i,loPath,0)),thickComp) > pth(IntVect(D_DECL(i,loPath,0)),thickComp))
+                        if (pth(IntVect(AMREX_D_DECL(i,loPath,0)),thickComp) > pth(IntVect(AMREX_D_DECL(i,loPath,0)),thickComp))
                             amrex::Abort("Path oriented backwards");
                         
-                        if (loVal > pth(IntVect(D_DECL(i,hiPath,0)),thickComp))
+                        if (loVal > pth(IntVect(AMREX_D_DECL(i,hiPath,0)),thickComp))
                         {
                             lIdx=hiPath-1;
                             rIdx=hiPath;
-                            lVal = pth(IntVect(D_DECL(i,lIdx,0)),thickComp); rVal=lVal;
+                            lVal = pth(IntVect(AMREX_D_DECL(i,lIdx,0)),thickComp); rVal=lVal;
                             frac = 1.0;
                         }
                         else if (loVal > lVal)
                         {
                             for (int j=loPath; (j<hiPath) && (!foundIt); ++j)
                             {
-                                rIdx = lIdx + 1;  rVal = pth(IntVect(D_DECL(i,rIdx,0)),thickComp);
+                                rIdx = lIdx + 1;  rVal = pth(IntVect(AMREX_D_DECL(i,rIdx,0)),thickComp);
                                 
                                 if ( (loVal >= lVal) && (loVal < rVal) )
                                 {
@@ -1642,8 +1642,8 @@ add_thermal_thickness_to_surf(const Vector<MultiFab*>&  paths,
                                 Real dd = 0;
                                 for (int d=0; d<BL_SPACEDIM; ++d)
                                 {
-                                    const Real& xL = pth(IntVect(D_DECL(i,j  ,0)),xComp+d);
-                                    const Real& xR = pth(IntVect(D_DECL(i,j+1,0)),xComp+d);
+                                    const Real& xL = pth(IntVect(AMREX_D_DECL(i,j  ,0)),xComp+d);
+                                    const Real& xR = pth(IntVect(AMREX_D_DECL(i,j+1,0)),xComp+d);
                                     dd += (xR-xL)*(xR-xL);
                                 }
                                 distance -= (j==lIdx ? (1.-frac) : 1.0) * std::sqrt(dd);
@@ -1656,8 +1656,8 @@ add_thermal_thickness_to_surf(const Vector<MultiFab*>&  paths,
                                 Real dd = 0;
                                 for (int d=0; d<BL_SPACEDIM; ++d)
                                 {
-                                    const Real& xL = pth(IntVect(D_DECL(i,j  ,0)),xComp+d);
-                                    const Real& xR = pth(IntVect(D_DECL(i,j+1,0)),xComp+d);
+                                    const Real& xL = pth(IntVect(AMREX_D_DECL(i,j  ,0)),xComp+d);
+                                    const Real& xR = pth(IntVect(AMREX_D_DECL(i,j+1,0)),xComp+d);
                                     dd += (xR-xL)*(xR-xL);
                                 }
                                 distance += (j==rIdx-1 ? frac : 1.0) * std::sqrt(dd);
@@ -1666,27 +1666,27 @@ add_thermal_thickness_to_surf(const Vector<MultiFab*>&  paths,
                         loLoc = distance;
                     }
                     {
-                        IntVect sIdx(D_DECL(i,0,0));
+                        IntVect sIdx(AMREX_D_DECL(i,0,0));
                         bool foundIt = false;
                         int lIdx=loPath, rIdx=lIdx+1;
-                        Real lVal = pth(IntVect(D_DECL(i,lIdx,0)),thickComp), rVal=lVal;
+                        Real lVal = pth(IntVect(AMREX_D_DECL(i,lIdx,0)),thickComp), rVal=lVal;
                         Real frac = 0.0;
                         
-                        if (pth(IntVect(D_DECL(i,loPath,0)),thickComp) > pth(IntVect(D_DECL(i,loPath,0)),thickComp))
+                        if (pth(IntVect(AMREX_D_DECL(i,loPath,0)),thickComp) > pth(IntVect(AMREX_D_DECL(i,loPath,0)),thickComp))
                             amrex::Abort("Path oriented backwards");
                         
-                        if (hiVal > pth(IntVect(D_DECL(i,hiPath,0)),thickComp))
+                        if (hiVal > pth(IntVect(AMREX_D_DECL(i,hiPath,0)),thickComp))
                         {
                             lIdx=hiPath-1;
                             rIdx=hiPath;
-                            lVal = pth(IntVect(D_DECL(i,lIdx,0)),thickComp); rVal=lVal;
+                            lVal = pth(IntVect(AMREX_D_DECL(i,lIdx,0)),thickComp); rVal=lVal;
                             frac = 1.0;
                         }
                         else if (hiVal > lVal)
                         {
                             for (int j=loPath; (j<hiPath) && (!foundIt); ++j)
                             {
-                                rIdx = lIdx + 1;  rVal = pth(IntVect(D_DECL(i,rIdx,0)),thickComp);
+                                rIdx = lIdx + 1;  rVal = pth(IntVect(AMREX_D_DECL(i,rIdx,0)),thickComp);
                                 
                                 if ( (hiVal >= lVal) && (hiVal < rVal) )
                                 {
@@ -1710,8 +1710,8 @@ add_thermal_thickness_to_surf(const Vector<MultiFab*>&  paths,
                                 Real dd = 0;
                                 for (int d=0; d<BL_SPACEDIM; ++d)
                                 {
-                                    const Real& xL = pth(IntVect(D_DECL(i,j  ,0)),xComp+d);
-                                    const Real& xR = pth(IntVect(D_DECL(i,j+1,0)),xComp+d);
+                                    const Real& xL = pth(IntVect(AMREX_D_DECL(i,j  ,0)),xComp+d);
+                                    const Real& xR = pth(IntVect(AMREX_D_DECL(i,j+1,0)),xComp+d);
                                     dd += (xR-xL)*(xR-xL);
                                 }
                                 distance -= (j==lIdx ? (1.-frac) : 1.0) * std::sqrt(dd);
@@ -1724,8 +1724,8 @@ add_thermal_thickness_to_surf(const Vector<MultiFab*>&  paths,
                                 Real dd = 0;
                                 for (int d=0; d<BL_SPACEDIM; ++d)
                                 {
-                                    const Real& xL = pth(IntVect(D_DECL(i,j  ,0)),xComp+d);
-                                    const Real& xR = pth(IntVect(D_DECL(i,j+1,0)),xComp+d);
+                                    const Real& xL = pth(IntVect(AMREX_D_DECL(i,j  ,0)),xComp+d);
+                                    const Real& xR = pth(IntVect(AMREX_D_DECL(i,j+1,0)),xComp+d);
                                     dd += (xR-xL)*(xR-xL);
                                 }
                                 distance += (j==rIdx-1 ? frac : 1.0) * std::sqrt(dd);
@@ -1891,27 +1891,27 @@ build_surface_at_isoVal(const Vector<MultiFab*>&  paths,
                 // For each path, search for isoVal
                 for (int i=0; i<Npaths; ++i)
                 {
-                    IntVect sIdx(D_DECL(i,0,0));
+                    IntVect sIdx(AMREX_D_DECL(i,0,0));
                     bool foundIt = false;
                     int lIdx=loPath, rIdx=lIdx+1;
-                    Real lVal = pth(IntVect(D_DECL(i,lIdx,0)),isoComp), rVal=lVal;
+                    Real lVal = pth(IntVect(AMREX_D_DECL(i,lIdx,0)),isoComp), rVal=lVal;
                     Real frac = 0.0;
 
-                    if (pth(IntVect(D_DECL(i,loPath,0)),isoComp) > pth(IntVect(D_DECL(i,loPath,0)),isoComp))
+                    if (pth(IntVect(AMREX_D_DECL(i,loPath,0)),isoComp) > pth(IntVect(AMREX_D_DECL(i,loPath,0)),isoComp))
                         amrex::Abort("Path oriented backwards");
 
-                    if (isoVal > pth(IntVect(D_DECL(i,hiPath,0)),isoComp))
+                    if (isoVal > pth(IntVect(AMREX_D_DECL(i,hiPath,0)),isoComp))
                     {
                         lIdx=hiPath-1;
                         rIdx=hiPath;
-                        lVal = pth(IntVect(D_DECL(i,lIdx,0)),isoComp); rVal=lVal;
+                        lVal = pth(IntVect(AMREX_D_DECL(i,lIdx,0)),isoComp); rVal=lVal;
                         frac = 1.0;
                     }
                     else if (isoVal > lVal)
                     {
                         for (int j=loPath; (j<hiPath) && (!foundIt); ++j)
                         {
-                            rIdx = lIdx + 1;  rVal = pth(IntVect(D_DECL(i,rIdx,0)),isoComp);
+                            rIdx = lIdx + 1;  rVal = pth(IntVect(AMREX_D_DECL(i,rIdx,0)),isoComp);
 
                             if ( (isoVal >= lVal) && (isoVal < rVal) )
                             {
@@ -1929,15 +1929,15 @@ build_surface_at_isoVal(const Vector<MultiFab*>&  paths,
                     // Compute position at isoVal
                     for (int d=0; d<BL_SPACEDIM; ++d)
                     {
-                        const Real& xL = pth(IntVect(D_DECL(i,lIdx,0)),xComp+d);
-                        const Real& xR = pth(IntVect(D_DECL(i,rIdx,0)),xComp+d);
+                        const Real& xL = pth(IntVect(AMREX_D_DECL(i,lIdx,0)),xComp+d);
+                        const Real& xR = pth(IntVect(AMREX_D_DECL(i,rIdx,0)),xComp+d);
                         my_altSurfData.push_back(xL + (xR-xL) * frac);
                     }
                     // Compute other values at isoVal as well
                     for (int d=0; d<nComp; ++d)
                     {
-                        const Real& xL = pth(IntVect(D_DECL(i,lIdx,0)),comps[d]);
-                        const Real& xR = pth(IntVect(D_DECL(i,rIdx,0)),comps[d]);
+                        const Real& xL = pth(IntVect(AMREX_D_DECL(i,lIdx,0)),comps[d]);
+                        const Real& xR = pth(IntVect(AMREX_D_DECL(i,rIdx,0)),comps[d]);
                         my_altSurfData.push_back(xL + (xR-xL) * frac);
                     }
                     // set distance to base pt of stream line (isoComp == isoVal)
@@ -1949,8 +1949,8 @@ build_surface_at_isoVal(const Vector<MultiFab*>&  paths,
                             Real dd = 0;
                             for (int d=0; d<BL_SPACEDIM; ++d)
                             {
-                                const Real& xL = pth(IntVect(D_DECL(i,j  ,0)),xComp+d);
-                                const Real& xR = pth(IntVect(D_DECL(i,j+1,0)),xComp+d);
+                                const Real& xL = pth(IntVect(AMREX_D_DECL(i,j  ,0)),xComp+d);
+                                const Real& xR = pth(IntVect(AMREX_D_DECL(i,j+1,0)),xComp+d);
                                 dd += (xR-xL)*(xR-xL);
                             }
                             distance -= (j==lIdx ? (1.-frac) : 1.0) * std::sqrt(dd);
@@ -1963,8 +1963,8 @@ build_surface_at_isoVal(const Vector<MultiFab*>&  paths,
                             Real dd = 0;
                             for (int d=0; d<BL_SPACEDIM; ++d)
                             {
-                                const Real& xL = pth(IntVect(D_DECL(i,j  ,0)),xComp+d);
-                                const Real& xR = pth(IntVect(D_DECL(i,j+1,0)),xComp+d);
+                                const Real& xL = pth(IntVect(AMREX_D_DECL(i,j  ,0)),xComp+d);
+                                const Real& xR = pth(IntVect(AMREX_D_DECL(i,j+1,0)),xComp+d);
                                 dd += (xR-xL)*(xR-xL);
                             }
                             distance += (j==rIdx-1 ? frac : 1.0) * std::sqrt(dd);
@@ -2285,7 +2285,7 @@ dump_ml_streamline_data(const std::string&       outFile,
 
               for (int L=b.smallEnd()[1]; L<=b.bigEnd()[1]; ++L)
               {
-                const IntVect iv(D_DECL(i,L,0));
+                const IntVect iv(AMREX_D_DECL(i,L,0));
                 for (int n=sComp; n<nComp; ++n)
                 {
                   ofs << (*data[lev])[j](iv,n) << " ";

--- a/Src/stream2plt.cpp
+++ b/Src/stream2plt.cpp
@@ -90,8 +90,8 @@ downsampleStreamData(const StreamData&                stream,
             {
                 int first_idx = map_baIdx_selectIdxPairs[box_id].front().first;
                 int last_idx = map_baIdx_selectIdxPairs[box_id].back().first;
-                Box bx(IntVect(D_DECL(first_idx,slo,0)),
-                       IntVect(D_DECL(last_idx,shi,0)));
+                Box bx(IntVect(AMREX_D_DECL(first_idx,slo,0)),
+                       IntVect(AMREX_D_DECL(last_idx,shi,0)));
                 bldst.push_back(bx);
             }
         }
@@ -171,7 +171,7 @@ write_tec_binary(const FArrayBox&     strm,
     Vector<Real> loc(BL_SPACEDIM);
     const Box& box = strm.box();
     const IntVect ivst = box.smallEnd();
-    const IntVect ivmid(D_DECL(ivst[0],0,ivst[2]));
+    const IntVect ivmid(AMREX_D_DECL(ivst[0],0,ivst[2]));
     
     int nLines = box.length(0);
     int Npts = box.length(1);
@@ -306,7 +306,7 @@ write_tec_ascii(const FArrayBox&     strm,
             osf << "ZONE T=" << label << " I=" << Npts << " F=POINT" << endl;;                    
             for (int j=0; j<Npts; ++j)
             {
-              IntVect ivt = ivst + IntVect(D_DECL(i,j,0));
+              IntVect ivt = ivst + IntVect(AMREX_D_DECL(i,j,0));
               for (int n=0; n<nComp; ++n)
                 osf << strm(ivt,n) << " ";
               osf << '\n';
@@ -495,8 +495,8 @@ main (int   argc,
     int slo = stream.StreamIdxLo();
     int shi = stream.StreamIdxHi();
 
-    Box finalBox(IntVect(D_DECL(0,slo,0)),
-                 IntVect(D_DECL(nLines-1,shi,0)));
+    Box finalBox(IntVect(AMREX_D_DECL(0,slo,0)),
+                 IntVect(AMREX_D_DECL(nLines-1,shi,0)));
     BoxArray finalBa(finalBox);
     DistributionMapping dmfinal(finalBa);
     MultiFab finalMF(finalBa,dmfinal,selectedNames.size(),0);
@@ -526,13 +526,13 @@ main (int   argc,
                     for (SelectionMapList::const_iterator it = line_map.begin(); it!=line_map.end(); ++it)
                     {
                         int old_local_idx = it->second;                
-                        Box srcBox(IntVect(D_DECL(old_local_idx,slo,0)),
-                                   IntVect(D_DECL(old_local_idx,shi,0)));
+                        Box srcBox(IntVect(AMREX_D_DECL(old_local_idx,slo,0)),
+                                   IntVect(AMREX_D_DECL(old_local_idx,shi,0)));
                         
                         int new_global_idx = it->first;
                         BL_ASSERT(new_global_idx < nLines);
-                        Box dstBox(IntVect(D_DECL(new_global_idx,slo,0)),
-                                   IntVect(D_DECL(new_global_idx,shi,0)));
+                        Box dstBox(IntVect(AMREX_D_DECL(new_global_idx,slo,0)),
+                                   IntVect(AMREX_D_DECL(new_global_idx,shi,0)));
                         
                         BL_ASSERT(srcFab.box().contains(srcBox));
                         BL_ASSERT(dstFab.box().contains(dstBox));
@@ -605,7 +605,7 @@ main (int   argc,
             {
                 for (int i=0; i<nLines; ++i)
                 {
-                    IntVect ivs(D_DECL(i,0.5*(slo+shi),0));
+                    IntVect ivs(AMREX_D_DECL(i,0.5*(slo+shi),0));
                     Real radius = 0;
                     for (int n=0; n<2; ++n) {
                         Real val = fab(ivs,n);

--- a/Src/streamTubeStats.cpp
+++ b/Src/streamTubeStats.cpp
@@ -706,7 +706,7 @@ main (int   argc,
            volInt[oFirstAvg+j] = 0;
            for (int k=0; k<nodesPerElt; ++k){
               volInt[oFirstAvg+j] +=
-                  (*streamlines[n[k]->amr_lev])[n[k]->box_idx](IntVect(D_DECL(n[k]->pt_idx,0,0)),comp);
+                  (*streamlines[n[k]->amr_lev])[n[k]->box_idx](IntVect(AMREX_D_DECL(n[k]->pt_idx,0,0)),comp);
            }
            
            volInt[oFirstAvg+j] /= nodesPerElt;
@@ -717,7 +717,7 @@ main (int   argc,
         {
             volInt[oFirstAux+j] = 0;
             for (int k=0; k<nodesPerElt; ++k)
-                volInt[oFirstAux+j] += auxNodes(IntVect(D_DECL(faceData[offset+k]-1,0,0)),j);
+                volInt[oFirstAux+j] += auxNodes(IntVect(AMREX_D_DECL(faceData[offset+k]-1,0,0)),j);
             volInt[oFirstAux+j] *= 1/nodesPerElt;
         }
 
@@ -887,7 +887,7 @@ max_grad(const MLloc&            p,
     IntVect hi, lo;
     Real hiVal, loVal, hiX[3], loX[3], tot;
 
-    hi = IntVect(D_DECL(p.pt_idx,fab.box().smallEnd()[1],0));
+    hi = IntVect(AMREX_D_DECL(p.pt_idx,fab.box().smallEnd()[1],0));
     BL_ASSERT(fab.box().contains(hi));
     hiVal = fab(hi,comp);
     for (int j=0; j<BL_SPACEDIM; ++j)
@@ -917,7 +917,7 @@ max_grad(const MLloc&            p,
     }
     eps = 1.e-4*maxs;
 
-    hi = IntVect(D_DECL(p.pt_idx,fab.box().smallEnd()[1],0));
+    hi = IntVect(AMREX_D_DECL(p.pt_idx,fab.box().smallEnd()[1],0));
     int loc = 1;
     for (int i=1; i<nPts; ++i)
     {
@@ -968,7 +968,7 @@ peak_val(const MLloc&            p,
     const int nPts = fab.box().length(1);
 
     int peakValLoc = fab.box().smallEnd()[1];
-    IntVect iv = IntVect(D_DECL(p.pt_idx,peakValLoc,0));
+    IntVect iv = IntVect(AMREX_D_DECL(p.pt_idx,peakValLoc,0));
     BL_ASSERT(fab.box().contains(iv));
     Real peakVal = fab(iv,pComp);
     for (int i=1; i<nPts; ++i)
@@ -1024,10 +1024,10 @@ wedge_volume_int(const Vector<const MLloc*>& p,
     {
         Real A[2], B[2], C[2], D[2];
 
-        const IntVect iv1(D_DECL(P1,ptOnStr,0));
-        const IntVect iv2(D_DECL(P2,ptOnStr,0));
-        const IntVect iv1p(D_DECL(P1,ptOnStr+1,0));
-        const IntVect iv2p(D_DECL(P2,ptOnStr+1,0));
+        const IntVect iv1(AMREX_D_DECL(P1,ptOnStr,0));
+        const IntVect iv2(AMREX_D_DECL(P2,ptOnStr,0));
+        const IntVect iv1p(AMREX_D_DECL(P1,ptOnStr+1,0));
+        const IntVect iv2p(AMREX_D_DECL(P2,ptOnStr+1,0));
 
         A[0] = (*data[L1])[B1](iv1,idX[0]);
         A[1] = (*data[L1])[B1](iv1,idX[1]);
@@ -1078,12 +1078,12 @@ wedge_volume_int(const Vector<const MLloc*>& p,
 
         Real A[3], B[3], C[3], D[3], E[3], F[3];
 
-        const IntVect iv1(D_DECL(P1,ptOnStr,0));
-        const IntVect iv2(D_DECL(P2,ptOnStr,0));
-        const IntVect iv3(D_DECL(P3,ptOnStr,0));
-        const IntVect iv1p(D_DECL(P1,ptOnStr+1,0));
-        const IntVect iv2p(D_DECL(P2,ptOnStr+1,0));
-        const IntVect iv3p(D_DECL(P3,ptOnStr+1,0));
+        const IntVect iv1(AMREX_D_DECL(P1,ptOnStr,0));
+        const IntVect iv2(AMREX_D_DECL(P2,ptOnStr,0));
+        const IntVect iv3(AMREX_D_DECL(P3,ptOnStr,0));
+        const IntVect iv1p(AMREX_D_DECL(P1,ptOnStr+1,0));
+        const IntVect iv2p(AMREX_D_DECL(P2,ptOnStr+1,0));
+        const IntVect iv3p(AMREX_D_DECL(P3,ptOnStr+1,0));
 
         A[0] = (*data[L1])[B1](iv1,idX[0]);
         A[1] = (*data[L1])[B1](iv1,idX[1]);
@@ -1131,12 +1131,12 @@ wedge_volume_int(const Vector<const MLloc*>& p,
             const Real vol_ABDF = tetVol(B,D,F,A);
             const Real vol_ABEF = tetVol(B,E,F,A);
 
-            const Real vA = (*data[L1])[B1](IntVect(D_DECL(P1,ptOnStr,  0)),comp);
-            const Real vB = (*data[L2])[B2](IntVect(D_DECL(P2,ptOnStr,  0)),comp);
-            const Real vC = (*data[L3])[B3](IntVect(D_DECL(P3,ptOnStr,  0)),comp);                    
-            const Real vD = (*data[L1])[B1](IntVect(D_DECL(P1,ptOnStr+1,0)),comp);
-            const Real vE = (*data[L2])[B2](IntVect(D_DECL(P2,ptOnStr+1,0)),comp);
-            const Real vF = (*data[L3])[B3](IntVect(D_DECL(P3,ptOnStr+1,0)),comp);
+            const Real vA = (*data[L1])[B1](IntVect(AMREX_D_DECL(P1,ptOnStr,  0)),comp);
+            const Real vB = (*data[L2])[B2](IntVect(AMREX_D_DECL(P2,ptOnStr,  0)),comp);
+            const Real vC = (*data[L3])[B3](IntVect(AMREX_D_DECL(P3,ptOnStr,  0)),comp);                    
+            const Real vD = (*data[L1])[B1](IntVect(AMREX_D_DECL(P1,ptOnStr+1,0)),comp);
+            const Real vE = (*data[L2])[B2](IntVect(AMREX_D_DECL(P2,ptOnStr+1,0)),comp);
+            const Real vF = (*data[L3])[B3](IntVect(AMREX_D_DECL(P3,ptOnStr+1,0)),comp);
 
             // These are actually 24 times the integral
             const Real int_1 = ( (vD+vA+vB+vC)*vol_DABC + 
@@ -1197,8 +1197,8 @@ wedge_surf_area(Vector<const MLloc*> p,
     if (nComp==2)
     {
         Real A[2], B[2];
-        const IntVect iv1(D_DECL(P1,ptOnStr,0));
-        const IntVect iv2(D_DECL(P2,ptOnStr,0));
+        const IntVect iv1(AMREX_D_DECL(P1,ptOnStr,0));
+        const IntVect iv2(AMREX_D_DECL(P2,ptOnStr,0));
         
         A[0] = (*data[L1])[B1](iv1,idX[0]);
         A[1] = (*data[L1])[B1](iv1,idX[1]);
@@ -1218,9 +1218,9 @@ wedge_surf_area(Vector<const MLloc*> p,
         int P3 = p[2]->pt_idx;
         
         Real A[3], B[3], C[3];
-        const IntVect iv1(D_DECL(P1,ptOnStr,0));
-        const IntVect iv2(D_DECL(P2,ptOnStr,0));
-        const IntVect iv3(D_DECL(P3,ptOnStr,0));
+        const IntVect iv1(AMREX_D_DECL(P1,ptOnStr,0));
+        const IntVect iv2(AMREX_D_DECL(P2,ptOnStr,0));
+        const IntVect iv3(AMREX_D_DECL(P3,ptOnStr,0));
         
         A[0] = (*data[L1])[B1](iv1,idX[0]);
         A[1] = (*data[L1])[B1](iv1,idX[1]);
@@ -1509,11 +1509,11 @@ write_binary_tec_file(const std::string&          outfile,
         {
             const MLloc& n = nodeMap[ faceData[offset+j] - 1 ];
             const IntVect iv = IntVect(n.pt_idx,ptOnStr,0);
-            nodeFab(IntVect(D_DECL(offset+j,0,0)),0) = (*nodes[n.amr_lev])[n.box_idx](iv,idX[0]);
-            nodeFab(IntVect(D_DECL(offset+j,0,0)),1) = (*nodes[n.amr_lev])[n.box_idx](iv,idX[1]);
-            nodeFab(IntVect(D_DECL(offset+j,0,0)),2) = (*nodes[n.amr_lev])[n.box_idx](iv,idX[2]);
+            nodeFab(IntVect(AMREX_D_DECL(offset+j,0,0)),0) = (*nodes[n.amr_lev])[n.box_idx](iv,idX[0]);
+            nodeFab(IntVect(AMREX_D_DECL(offset+j,0,0)),1) = (*nodes[n.amr_lev])[n.box_idx](iv,idX[1]);
+            nodeFab(IntVect(AMREX_D_DECL(offset+j,0,0)),2) = (*nodes[n.amr_lev])[n.box_idx](iv,idX[2]);
             for (int m=0; m<eltData[0].size(); ++m)
-                nodeFab(IntVect(D_DECL(offset+j,0,0)),m+BL_SPACEDIM) = eltData[i][m];
+                nodeFab(IntVect(AMREX_D_DECL(offset+j,0,0)),m+BL_SPACEDIM) = eltData[i][m];
             connData[offset+j] = offset+ j + 1;
         }
     }
@@ -1560,7 +1560,7 @@ write_ascii_tec_file(const std::string&           outfile,
     int nodesPerElt = faceData.size() / nElts;
     int nPts = nElts*nodesPerElt;
     
-    Box nbox(IntVect::TheZeroVector(),IntVect(D_DECL(nPts-1,0,0)));
+    Box nbox(IntVect::TheZeroVector(),IntVect(AMREX_D_DECL(nPts-1,0,0)));
     FArrayBox nodeFab(nbox,nComp);
     Vector<int> connData(nPts);
     // Build nodeFab so we can write it, use ptOnStr=0 to get point at surface
@@ -1575,11 +1575,11 @@ write_ascii_tec_file(const std::string&           outfile,
         for (int j=0; j<nodesPerElt; ++j)
         {
             const MLloc& n = nodeMap[ faceData[offset+j] - 1 ];
-            const IntVect iv = IntVect(D_DECL(n.pt_idx,ptOnStr,0));
+            const IntVect iv = IntVect(AMREX_D_DECL(n.pt_idx,ptOnStr,0));
             for (int k=0; k<BL_SPACEDIM; ++k)
-                nodeFab(IntVect(D_DECL(offset+j,0,0)),k) = (*nodes[n.amr_lev])[n.box_idx](iv,idX[k]);
+                nodeFab(IntVect(AMREX_D_DECL(offset+j,0,0)),k) = (*nodes[n.amr_lev])[n.box_idx](iv,idX[k]);
             for (int m=0; m<eltData[0].size(); ++m)
-                nodeFab(IntVect(D_DECL(offset+j,0,0)),m+BL_SPACEDIM) = eltData[i][m];
+                nodeFab(IntVect(AMREX_D_DECL(offset+j,0,0)),m+BL_SPACEDIM) = eltData[i][m];
             connData[offset+j] = offset+ j + 1;
         }
     }
@@ -1637,7 +1637,7 @@ write_binary_mef_file(const std::string&           outfile,
 #ifdef FAKE_NODE_MEF
     int nPts = nElts*nodesPerElt;
     
-    Box nbox(IntVect::TheZeroVector(),IntVect(D_DECL(nPts-1,0,0)));
+    Box nbox(IntVect::TheZeroVector(),IntVect(AMREX_D_DECL(nPts-1,0,0)));
     FArrayBox fab(nbox,nComp);
     Vector<int> connData(nPts);
     // Build fab so we can write it, use ptOnStr=0 to get point at surface
@@ -1653,7 +1653,7 @@ write_binary_mef_file(const std::string&           outfile,
         for (int j=0; j<nodesPerElt; ++j)
         {
             const MLloc& n = nodeMap[ faceData[offset+j] - 1 ];
-            const IntVect iv = IntVect(D_DECL(n.pt_idx,ptOnStr,0));
+            const IntVect iv = IntVect(AMREX_D_DECL(n.pt_idx,ptOnStr,0));
             
             for (int k=0; k<BL_SPACEDIM; ++k)
                 *floatDat++ = (*nodes[n.amr_lev])[n.box_idx](iv,idX[k]);
@@ -1691,7 +1691,7 @@ write_binary_mef_file(const std::string&           outfile,
         
 #ifndef FAKE_NODE_MEF
     int nCompElt = eltData[0].size();
-    Box ebox(IntVect::TheZeroVector(),IntVect(D_DECL(nElts-1,0,0)));
+    Box ebox(IntVect::TheZeroVector(),IntVect(AMREX_D_DECL(nElts-1,0,0)));
     fab.resize(ebox,nCompElt);
     floatDat = fab.dataPtr();
     for (int i=0; i<nElts; ++i)

--- a/Src/surfDATtoMEF.cpp
+++ b/Src/surfDATtoMEF.cpp
@@ -168,7 +168,7 @@ class FABdata
 public:
     FABdata(SIZET i, SIZET n)
         {fab.resize(Box(IntVect::TheZeroVector(),
-                        IntVect(D_DECL(i-1,0,0))),n);}
+                        IntVect(AMREX_D_DECL(i-1,0,0))),n);}
     Real& operator[](SIZET i) {return fab.dataPtr()[i];}
     FArrayBox fab;
     SIZET boxSize;

--- a/Tools/GNUmake/Make.Analysis
+++ b/Tools/GNUmake/Make.Analysis
@@ -9,7 +9,7 @@ TOP := $(PELE_ANALYSIS_HOME)
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 
 
-all: $(executable) 
+all: $(executable)
 	$(SILENT) $(RM) AMReX_buildInfo.cpp
 	@echo SUCCESS
 
@@ -45,7 +45,7 @@ ifeq ($(NEED_QSLIM),TRUE)
   GFX_ROOT       = $(QSLIM_LOC)/libgfx
   INCLUDE_LOCATIONS += $(QSLIM_TOOL) ${MIX_ROOT} ${GFX_ROOT}/include
   LIBRARY_LOCATIONS += ${MIX_ROOT} ${GFX_ROOT}/src
-  LIBRARIES += -lmix -lgfx 
+  LIBRARIES += -lmix -lgfx
   DEFINES += -DHAVE_CONFIG_H -DHAVE_BOOL
   VPATH_LOCATIONS += $(QSLIM_TOOL)
 endif
@@ -95,7 +95,7 @@ qslimclean:
 	@echo "==> Removing qslim library"
 	@cd $(QSLIM_LOC)/libgfx/src; $(MAKE) clean
 	@cd $(QSLIM_LOC)/mixkit/src; $(MAKE) clean
-	
+
 #-----------------------------------------------------------------------------
 # for debugging.  To see the value of a Makefile variable,
 # e.g. Fmlocs, simply do "make print-Fmlocs".  This will


### PR DESCRIPTION
Copy from PelePhysics to add basic CI testing

Includes:
- Installing dependencies (qslim and sundials)
- Building several of the tools in Src requiring various capabilities:
  - template
  - avgPltFiles
  - isosurface (distance)
  - decimateMEF (qslim)
  - partStream (particles)
  - plotTransportCoeff (ModelSpecificAnalysis)
  - plotTYtoLe (ModelSpecificAnalysis)
- compilers: gnu, llvm, and gnu in debug mode

Does not include:
- Formatting, spelling, etc
- GPU compilation
- Actually running any of the tools
- Many of the tools are not even built, although the rest could be added easily

@jrood-nrel: I don't know what I'm doing with the Ccache stuff at all, but hopefully it all still works because it is a direct copy from PelePhysics. But please review that in particular.

@ThomasHowarth: This can at least give a starting point for any further tests if you want to add them