### PR TITLE
Update the HDF5 converter

### DIFF
--- a/Src/convert2hdf5.cpp
+++ b/Src/convert2hdf5.cpp
@@ -8,8 +8,6 @@
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_PlotFileUtilHDF5.H>
 
-using namespace amrex;
-
 static void print_usage(int, char *argv[]) {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile infile=f1 [options] \n\tOptions:\n";
@@ -17,7 +15,7 @@ static void print_usage(int, char *argv[]) {
 }
 
 std::string getFileRoot(const std::string &infile) {
-  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  std::vector<std::string> tokens = amrex::Tokenize(infile, std::string("/"));
   return tokens[tokens.size() - 1];
 }
 
@@ -27,61 +25,52 @@ int main(int argc, char *argv[]) {
     if (argc < 2) {
       print_usage(argc, argv);
     }
+    amrex::Real dRunTime1 = amrex::ParallelDescriptor::second();
 
-    // ---------------------------------------------------------------------
-    // Set defaults input values
-    // ---------------------------------------------------------------------
     int finestLevel = 1000;
-
-    // ---------------------------------------------------------------------
-    // ParmParse
-    // ---------------------------------------------------------------------
-    ParmParse pp;
-
+    amrex::ParmParse pp;
     if (pp.contains("help")) {
       print_usage(argc, argv);
     }
-
     pp.query("finestLevel", finestLevel);
-
     std::string plotFileName;
     pp.get("infile", plotFileName);
 
     // Initialize DataService
-    DataServices::SetBatchMode();
-    Amrvis::FileType fileType(Amrvis::NEWPLT);
-    DataServices dataServices(plotFileName, fileType);
+    amrex::DataServices::SetBatchMode();
+    amrex::Amrvis::FileType fileType(amrex::Amrvis::NEWPLT);
+    amrex::DataServices dataServices(plotFileName, fileType);
     if (!dataServices.AmrDataOk()) {
-      DataServices::Dispatch(DataServices::ExitRequest, NULL);
+      amrex::DataServices::Dispatch(amrex::DataServices::ExitRequest, NULL);
     }
-    AmrData &amrData = dataServices.AmrDataRef();
+    amrex::AmrData &amrData = dataServices.AmrDataRef();
 
     // Plotfile global infos
     finestLevel = std::min(finestLevel, amrData.FinestLevel());
     int Nlev = finestLevel + 1;
-    const Vector<std::string> &plotVarNames = amrData.PlotVarNames();
+    const amrex::Vector<std::string> &plotVarNames = amrData.PlotVarNames();
     int nvars = plotVarNames.size();
     int id_comp_last = 0;
-    RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
-    Vector<int> is_per(AMREX_SPACEDIM, 0);
+    amrex::RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
+    amrex::Vector<int> is_per(AMREX_SPACEDIM, 0);
     int coord = 0;
 
     // ---------------------------------------------------------------------
     // Let's start the real work
     // ---------------------------------------------------------------------
-    Vector<MultiFab *> fileData(Nlev);
-    Vector<Geometry> geoms(Nlev);
+    amrex::Vector<amrex::MultiFab *> fileData(Nlev);
+    amrex::Vector<amrex::Geometry> geoms(Nlev);
     const int nGrow = 1;
 
     // Read data on all the levels
     for (int lev = 0; lev < Nlev; ++lev) {
-      const DistributionMapping dm(amrData.boxArray(lev));
+      const amrex::DistributionMapping dm(amrData.boxArray(lev));
       geoms[lev] =
-          Geometry(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
-      fileData[lev] = new MultiFab(amrData.boxArray(lev), dm, nvars, 0);
+          amrex::Geometry(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
+      fileData[lev] = new amrex::MultiFab(amrData.boxArray(lev), dm, nvars, 0);
     }
 
-    Vector<int> idcomp;
+    amrex::Vector<int> idcomp;
     for (int i = 0; i < plotVarNames.size();
          ++i) {            // loop though current pltfile variable names
       idcomp.push_back(i); // sets index location of plotVarName that matches
@@ -101,19 +90,24 @@ int main(int argc, char *argv[]) {
     std::string hdf5_compression{"ZLIB@9"};
     pp.query("hdf5_compression", hdf5_compression);
     std::string outfile(getFileRoot(plotFileName) + "_hdf5");
-    Print() << "Writing new data to " << outfile << std::endl;
-    Vector<int> isteps(Nlev, 0);
-    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::Print() << "Writing new data to " << outfile << std::endl;
+    amrex::Vector<int> isteps(Nlev, 0);
+    amrex::Vector<amrex::IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
     amrex::WriteMultiLevelPlotfileHDF5SingleDset(
-        outfile, Nlev, GetVecOfConstPtrs(fileData), plotVarNames, geoms,
+        outfile, Nlev, amrex::GetVecOfConstPtrs(fileData), plotVarNames, geoms,
         amrData.Time(), isteps, refRatios, hdf5_compression);
+
+    amrex::Real dRunTime2 = amrex::ParallelDescriptor::second();
+    amrex::Real runtime_total = dRunTime2 - dRunTime1;
+
+    const int IOProc = amrex::ParallelDescriptor::IOProcessorNumber();
+    amrex::ParallelDescriptor::ReduceRealMax(runtime_total, IOProc);
 
     if (amrex::ParallelDescriptor::IOProcessor()) {
       amrex::Print() << "Run time = " << runtime_total << std::endl;
-      amrex::Print() << "Run time w/o init = " << runtime_timestep << std::endl;
     }
   }
 
-  Finalize();
+  amrex::Finalize();
   return 0;
 }

--- a/Src/convert2hdf5.cpp
+++ b/Src/convert2hdf5.cpp
@@ -1,46 +1,37 @@
-#include <string>
 #include <iostream>
 #include <set>
+#include <string>
 
-#include <AMReX_ParmParse.H>
-#include <AMReX_MultiFab.H>
 #include <AMReX_DataServices.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_ParmParse.H>
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_PlotFileUtilHDF5.H>
 
 using namespace amrex;
 
-static
-void 
-print_usage (int,
-             char* argv[])
-{
+static void print_usage(int, char *argv[]) {
   std::cerr << "usage:\n";
   std::cerr << argv[0] << " infile infile=f1 [options] \n\tOptions:\n";
   exit(1);
 }
 
-std::string
-getFileRoot(const std::string& infile)
-{
-  std::vector<std::string> tokens = Tokenize(infile,std::string("/"));
-  return tokens[tokens.size()-1];
+std::string getFileRoot(const std::string &infile) {
+  std::vector<std::string> tokens = Tokenize(infile, std::string("/"));
+  return tokens[tokens.size() - 1];
 }
 
-int
-main (int   argc,
-      char* argv[])
-{
-  amrex::Initialize(argc,argv);
+int main(int argc, char *argv[]) {
+  amrex::Initialize(argc, argv);
   {
     if (argc < 2) {
-      print_usage(argc,argv);
+      print_usage(argc, argv);
     }
 
     // ---------------------------------------------------------------------
     // Set defaults input values
     // ---------------------------------------------------------------------
-    int finestLevel           = 1000;
+    int finestLevel = 1000;
 
     // ---------------------------------------------------------------------
     // ParmParse
@@ -48,88 +39,81 @@ main (int   argc,
     ParmParse pp;
 
     if (pp.contains("help")) {
-      print_usage(argc,argv);
+      print_usage(argc, argv);
     }
 
-    pp.query("finestLevel",finestLevel);
+    pp.query("finestLevel", finestLevel);
 
-    std::string plotFileName; pp.get("infile",plotFileName);
-    
-   
+    std::string plotFileName;
+    pp.get("infile", plotFileName);
+
     // Initialize DataService
     DataServices::SetBatchMode();
     Amrvis::FileType fileType(Amrvis::NEWPLT);
     DataServices dataServices(plotFileName, fileType);
-    if( ! dataServices.AmrDataOk()) {
+    if (!dataServices.AmrDataOk()) {
       DataServices::Dispatch(DataServices::ExitRequest, NULL);
     }
-    AmrData& amrData = dataServices.AmrDataRef();
+    AmrData &amrData = dataServices.AmrDataRef();
 
     // Plotfile global infos
-    finestLevel = std::min(finestLevel,amrData.FinestLevel());
+    finestLevel = std::min(finestLevel, amrData.FinestLevel());
     int Nlev = finestLevel + 1;
-    const Vector<std::string>& plotVarNames = amrData.PlotVarNames();
+    const Vector<std::string> &plotVarNames = amrData.PlotVarNames();
     int nvars = plotVarNames.size();
-    int id_comp_last = 0;    
-    RealBox rb(&(amrData.ProbLo()[0]), 
-               &(amrData.ProbHi()[0]));
-
-
-    // Check symmetry/periodicity in given coordinate direction
-    Vector<int> sym_dir(AMREX_SPACEDIM,0);
-    pp.queryarr("sym_dir",sym_dir,0,AMREX_SPACEDIM);  
-
-    Vector<int> is_per(AMREX_SPACEDIM,0);
-    pp.queryarr("is_per",is_per,0,AMREX_SPACEDIM);
-    Print() << "Periodicity assumed for this case: ";
-    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        Print() << is_per[idim] << " ";
-    }
-    Print() << "\n";
-
+    int id_comp_last = 0;
+    RealBox rb(&(amrData.ProbLo()[0]), &(amrData.ProbHi()[0]));
+    Vector<int> is_per(AMREX_SPACEDIM, 0);
     int coord = 0;
 
     // ---------------------------------------------------------------------
     // Let's start the real work
     // ---------------------------------------------------------------------
-    Vector<MultiFab*> fileData(Nlev);
+    Vector<MultiFab *> fileData(Nlev);
     Vector<Geometry> geoms(Nlev);
     const int nGrow = 1;
 
     // Read data on all the levels
-    for (int lev=0; lev<Nlev; ++lev) {
+    for (int lev = 0; lev < Nlev; ++lev) {
       const DistributionMapping dm(amrData.boxArray(lev));
-      geoms[lev] = Geometry(amrData.ProbDomain()[lev],&rb,coord,&(is_per[0]));
-      fileData[lev] = new MultiFab(amrData.boxArray(lev),dm,nvars,0);
+      geoms[lev] =
+          Geometry(amrData.ProbDomain()[lev], &rb, coord, &(is_per[0]));
+      fileData[lev] = new MultiFab(amrData.boxArray(lev), dm, nvars, 0);
     }
- 
+
     Vector<int> idcomp;
-    for (int i = 0; i < plotVarNames.size(); ++i) {  // loop though current pltfile variable names
-	  idcomp.push_back(i);                       // sets index location of plotVarName that matches
+    for (int i = 0; i < plotVarNames.size();
+         ++i) {            // loop though current pltfile variable names
+      idcomp.push_back(i); // sets index location of plotVarName that matches
+    }
+
+    for (int lev = 0; lev < Nlev; ++lev) {
+      for (int i = 0; i < nvars; ++i) {
+        fileData[lev]->ParallelCopy(amrData.GetGrids(lev, idcomp[i]), 0,
+                                    id_comp_last + i, 1);
       }
- 
-        
-    for (int lev=0; lev<Nlev; ++lev) {
-	for (int i=0; i<nvars; ++i) {
-	  fileData[lev]->ParallelCopy(amrData.GetGrids(lev,idcomp[i]),0,id_comp_last+i,1);	    
-	}
-    }   
-  
+    }
 
     // ---------------------------------------------------------------------
     // Write the results
-    // ---------------------------------------------------------------------    
-    
+    // ---------------------------------------------------------------------
+
     std::string hdf5_compression{"ZLIB@9"};
-    pp.query("hdf5_compression",hdf5_compression);
+    pp.query("hdf5_compression", hdf5_compression);
     std::string outfile(getFileRoot(plotFileName) + "_hdf5");
     Print() << "Writing new data to " << outfile << std::endl;
     Vector<int> isteps(Nlev, 0);
-    Vector<IntVect> refRatios(Nlev-1,{AMREX_D_DECL(2, 2, 2)});
-    amrex::WriteMultiLevelPlotfileHDF5SingleDset(outfile, Nlev, GetVecOfConstPtrs(fileData), plotVarNames,
-                                   geoms, amrData.Time(), isteps, refRatios, hdf5_compression);
+    Vector<IntVect> refRatios(Nlev - 1, {AMREX_D_DECL(2, 2, 2)});
+    amrex::WriteMultiLevelPlotfileHDF5SingleDset(
+        outfile, Nlev, GetVecOfConstPtrs(fileData), plotVarNames, geoms,
+        amrData.Time(), isteps, refRatios, hdf5_compression);
 
+    if (amrex::ParallelDescriptor::IOProcessor()) {
+      amrex::Print() << "Run time = " << runtime_total << std::endl;
+      amrex::Print() << "Run time w/o init = " << runtime_timestep << std::endl;
+    }
   }
+
   Finalize();
   return 0;
 }

--- a/Src/convert2hdf5.cpp
+++ b/Src/convert2hdf5.cpp
@@ -55,9 +55,7 @@ int main(int argc, char *argv[]) {
     amrex::Vector<int> is_per(AMREX_SPACEDIM, 0);
     int coord = 0;
 
-    // ---------------------------------------------------------------------
-    // Let's start the real work
-    // ---------------------------------------------------------------------
+    // Copy data
     amrex::Vector<amrex::MultiFab *> fileData(Nlev);
     amrex::Vector<amrex::Geometry> geoms(Nlev);
     const int nGrow = 1;
@@ -83,10 +81,7 @@ int main(int argc, char *argv[]) {
       }
     }
 
-    // ---------------------------------------------------------------------
     // Write the results
-    // ---------------------------------------------------------------------
-
     std::string hdf5_compression{"ZLIB@9"};
     pp.query("hdf5_compression", hdf5_compression);
     std::string outfile(getFileRoot(plotFileName) + "_hdf5");


### PR DESCRIPTION
Major changes:
- remove `amrex` namespace usage and be explicit
- clang-format
- add a run time output (so we know how long the script took)
- remove some unused parmparsed variables (they aren't useful)
- comment formating